### PR TITLE
chore(ci): add explicit read-only permissions to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/main_ci.yaml
+++ b/.github/workflows/main_ci.yaml
@@ -13,6 +13,9 @@ on:
 # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
chore(ci): add explicit read-only permissions to GITHUB_TOKEN