### PR TITLE
chore(ci): upgrade actions to v4, add timeout, simplify run steps

### DIFF
--- a/.github/workflows/main_ci.yaml
+++ b/.github/workflows/main_ci.yaml
@@ -2,15 +2,15 @@ name: CI
 
 on:
   push:
-    branches: 
+    branches:
       - master
       - main
   pull_request:
-    branches: 
+    branches:
       - master
       - main
 
-# Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
@@ -19,13 +19,15 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: sap-alm-dp-api-datasource
     steps:
-    - run: echo "This job was automatically triggered by a ${{github.event_name}} event."
-    - run: echo "This job is running on a ${{runner.os}} server"
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@v4
+
     - name: Setup Node.js environment
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20
         cache: 'yarn'
@@ -33,24 +35,18 @@ jobs:
 
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v5
+
     - name: Install Dependencies
-      run: cd sap-alm-dp-api-datasource && yarn install --immutable --prefer-offline
+      run: yarn install --immutable --prefer-offline
+
     - name: Check types
-      run: cd sap-alm-dp-api-datasource && yarn typecheck
+      run: yarn typecheck
+
     - name: Lint
-      run: cd sap-alm-dp-api-datasource && yarn lint
+      run: yarn lint
+
     - name: Unit tests
-      run: cd sap-alm-dp-api-datasource && yarn test:ci
+      run: yarn test:ci
 
     - name: Build Frontend
-      run: cd sap-alm-dp-api-datasource && yarn build
-
-#    - name: Start grafana docker
-#      run: cd sap-alm-dp-api-datasource && yarn server -d
-#
-#    - name: Run e2e tests
-#      run: cd sap-alm-dp-api-datasource && yarn e2e
-#
-#    - name: Stop grafana docker
-#      run: docker-compose down
-
+      run: yarn build


### PR DESCRIPTION
- Upgrade actions/checkout and actions/setup-node from v3 to v4
- Add timeout-minutes: 15 to prevent hung runners
- Add defaults.run.working-directory to remove repeated cd prefix
- Remove debug echo steps
- Remove commented-out dead e2e block